### PR TITLE
Added Dockerfile, secret_seed as a string and fixed little typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,3 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
-
-
-Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM python:3.11
+
+WORKDIR /audit
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y libportaudio2 && rm -rf /var/lib/apt/lists/*
+
+# Install Poetry
+RUN curl -sSL https://install.python-poetry.org | python3 - && \
+    ln -s /root/.local/bin/poetry /usr/local/bin/poetry
+
+# Ensure Poetry does NOT use virtual environments
+ENV POETRY_VIRTUALENVS_CREATE=false
+ENV PATH="/root/.local/bin:$PATH"
+
+# Copy dependency files first
+COPY pyproject.toml poetry.lock ./
+
+# Install Python dependencies
+RUN poetry install --no-root --no-interaction --no-ansi && poetry show
+
+# Copy the application code
+COPY . .
+
+# Explicitly set PYTHONPATH
+ENV PYTHONPATH="/usr/local/lib/python3.11/site-packages"
+
+# Set the command to run the audit script
+CMD ["python", "audit.py"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If you wish, rather than child hotkey or running a full validator with all the (
 set_weights:
   enabled: false
   ss58_address: 5GerCEPSx22bmr5Wnm2wj87SSpZiVvhVqFUrGG5795XkUbjr
-  secret_seed: 0x971c2a6674d0861ade72297d11110ce21c93734210527c8f4c9190c00139ce20
+  secret_seed: '0x971c2a6674d0861ade72297d11110ce21c93734210527c8f4c9190c00139ce20'
 ```
 ### Running the auditor
 Before attempting to run the auditor, be sure to go through the `config/config.yml` file and make any changes you wish. The biggest changes are:

--- a/audit.py
+++ b/audit.py
@@ -281,7 +281,7 @@ class Auditor:
         self.ss58_address = None
         self.keypair = None
         if self.config.set_weights.enabled:
-            self.ss58_address = self.config.set_weights.s58_address
+            self.ss58_address = self.config.set_weights.ss58_address
             self.keypair = Keypair.create_from_seed(self.config.set_weights.secret_seed)
 
     @contextmanager

--- a/config/config.yml
+++ b/config/config.yml
@@ -61,4 +61,4 @@ set_weights:
   # This is the ss58Address from the hotkey JSON
   ss58_address: 5GerCEPSx22bmr5Wnm2wj87SSpZiVvhVqFUrGG5795XkUbjr
   # This is the secretSeed value from hotkey JSON
-  secret_seed: 0x971c2a6674d0861ade72297d11110ce21c93734210527c8f4c9190c00139ce20
+  secret_seed: '0x971c2a6674d0861ade72297d11110ce21c93734210527c8f4c9190c00139ce20'


### PR DESCRIPTION
- Added a Dockerfile. Works properly right now for MUV's validator. (Also yeeted Dockerfile from the `.gitignore`)
```
2025-02-11 03:49:53.537 | INFO     | __main__:get_block_commit:731 - Attempting to process block=4860728
2025-02-11 03:49:53.672 | SUCCESS  | __main__:check_audit_report_integrity:771 - Verified commitment from 5CaqyHE9eBPyN469MNKor8R3zoyNsQwCzMZjd51xAR66S8tF in block 4860728 matches sha256: 2ca910be881244bdb41b25b088a0669d33dd63209290a420989d1273cdd45f4a
2025-02-11 03:49:53.673 | SUCCESS  | __main__:download_and_check_audit_reports:1175 - Successfully verified and persisted record 7a405322-4d9c-5df7-94dc-4650ced0ca3b from 5CaqyHE9eBPyN469MNKor8R3zoyNsQwCzMZjd51xAR66S8tF
2025-02-11 03:49:53.737 | SUCCESS  | __main__:load_audit_entries:949 - Populated 44 instance audit records for 5CaqyHE9eBPyN469MNKor8R3zoyNsQwCzMZjd51xAR66S8tF in record.entry_id='7a405322-4d9c-5df7-94dc-4650ced0ca3b'
2025-02-11 03:49:53.813 | SUCCESS  | __main__:load_miner_metrics:975 - Populated 57 self-reported chute metric records for 5CaqyHE9eBPyN469MNKor8R3zoyNsQwCzMZjd51xAR66S8tF in record.entry_id='7a405322-4d9c-5df7-94dc-4650ced0ca3b'
 16%|█▌        | 605/3791 [08:02<22:54,  2.32it/s]2025-02-11 03:49:53.814 | INFO     | __main__:download_and_check_audit_reports:1163 - Need to verify new audit entry: 5f735da3-a782-568a-89ab-eea6ca012896 for data between 2025-02-05 10:00:00 and 2025-02-05 11:00:00
2025-02-11 03:49:54.507 | INFO     | __main__:download_and_check_one:811 - Downloading and verifying CSV export of invocations: invocations/2025/02/05/11.csv
2025-02-11 03:49:55.166 | SUCCESS  | __main__:download_and_check_one:834 - Successfully downloaded CSV report data from /invocations/exports/2025/02/05/11.csv
2025-02-11 03:49:55.167 | SUCCESS  | __main__:download_and_check_one:839 - Successfully download audit data between 2025-02-05 10:00:00 and 2025-02-05 11:00:00 for hotkey 5Dt7HZ7Zpw4DppPxFM7Ke3Cm7sDAWhsZXmM5ZAmE7dSVJbcQ committed in block 4860728, now verifying...
2025-02-11 03:49:55.167 | INFO     | __main__:get_block_commit:731 - Attempting to process block=4860728
2025-02-11 03:49:55.211 | SUCCESS  | __main__:check_audit_report_integrity:771 - Verified commitment from 5Dt7HZ7Zpw4DppPxFM7Ke3Cm7sDAWhsZXmM5ZAmE7dSVJbcQ in block 4860728 matches sha256: a85523822b3980e1604447e0212044fc00eaa543f1f6a615add18bb4a490c456
2025-02-11 03:49:55.213 | SUCCESS  | __main__:download_and_check_audit_reports:1175 - Successfully verified and persisted record 5f735da3-a782-568a-89ab-eea6ca012896 from 5Dt7HZ7Zpw4DppPxFM7Ke3Cm7sDAWhsZXmM5ZAmE7dSVJbcQ
2025-02-11 03:49:55.213 | INFO     | __main__:load_invocations:853 - Inserting invocation records from /audit/reports/5f735da3-a782-568a-89ab-eea6ca012896/invocations/2025/02/05/11.csv
2025-02-11 03:50:03.230 | SUCCESS  | __main__:load_invocations:901 - Successfully loaded 28340 invocations from /audit/reports/5f735da3-a782-568a-89ab-eea6ca012896/invocations/2025/02/05/11.csv
```

- Added quotes to the `secret_seed` value. Without them, the secret seed is seen as an integer and everything explodes when trying to do this `self.keypair = Keypair.create_from_seed(self.config.set_weights.secret_seed)`

- Typo

